### PR TITLE
Adds preliminary server/API communication

### DIFF
--- a/server.js
+++ b/server.js
@@ -4,18 +4,65 @@ const express = require('express');
 const app = express();
 
 app.use(express.static(path.join(__dirname, '/client/dist')));
+app.use(express.urlencoded({ extended: true }));
+
+/*
+Request methods by app feature:
+Products (/products): GET
+Reviews (/reviews): GET, POST, PUT
+Q&A (/qa): GET, POST, PUT
+Related (?): ?
+*/
+
+// app.all('*', (req, res) => {
+//   console.log(req.method, req.params, req.body);
+//   api.fwd(req, res, (err, results) => {
+//     if (err) {
+//       console.log('API', err.stack);
+//     } else {
+//       console.log('Data from API:', results);
+//       res.json(results);
+//     }
+//     res.end();
+//   });
+// });
+
+// app.get('*', (req, res) => (
+//   api.fwd(req, res, (err, results) => {
+//     if (err) {
+//       console.log('API', err.stack);
+//     } else {
+//       console.log('Data from API:', results);
+//       res.json(results);
+//     }
+//     // res.end();
+//   })
+
+// ));
 
 app.get('/products', (req, res) => {
   api.getProducts((err, results) => {
     if (err) {
-      console.log('Failed to retrieve data from API', err.stack);
+      console.log('API', err.stack);
     } else {
-      console.log('Server has data from API', results);
+      console.log('Data from API', results);
       res.json(results);
     }
     res.end();
   });
 });
+
+// app.post('/products', (req, res) => {
+//   api.updateProducts(req.body, (err, results) => {
+//     if (err) {
+//       console.log('Product update', err.stack);
+//     } else {
+//       console.log('Product updated:', results);
+//       res.json(results);
+//     }
+//     res.end();
+//   });
+// });
 
 app.listen(3000, () => {
   console.log('Listening on port 3000');

--- a/server.js
+++ b/server.js
@@ -1,8 +1,21 @@
-const path = require('path')
+const api = require('./server/api.js');
+const path = require('path');
 const express = require('express');
 const app = express();
 
 app.use(express.static(path.join(__dirname, '/client/dist')));
+
+app.get('/products', (req, res) => {
+  api.getProducts((err, results) => {
+    if (err) {
+      console.log('Failed to retrieve data from API', err.stack);
+    } else {
+      console.log('Server has data from API', results);
+      res.json(results);
+    }
+    res.end();
+  });
+});
 
 app.listen(3000, () => {
   console.log('Listening on port 3000');

--- a/server/api.js
+++ b/server/api.js
@@ -1,0 +1,22 @@
+const axios = require('axios');
+const config = require('../config.js');
+
+axios.defaults.baseURL = config.API;
+axios.defaults.headers.common['Authorization'] = config.GITHUB_TOKEN;
+
+module.exports = {
+  // get: {
+  //   products:
+  // }
+  getProducts: (callback) => {
+    return axios.get('/products')
+      .then(res => {
+        // console.log('Data recieved from API:', res.data);
+        callback(null, res.data);
+      })
+      .catch(err => {
+        // console.log('API', err);
+        callback(err, null);
+      });
+  }
+};

--- a/server/api.js
+++ b/server/api.js
@@ -4,10 +4,27 @@ const config = require('../config.js');
 axios.defaults.baseURL = config.API;
 axios.defaults.headers.common['Authorization'] = config.GITHUB_TOKEN;
 
+const getByEndpoint = (endpoint, callback) => {
+  console.log('GET request to ' + endpoint);
+  return axios.get(endpoint)
+    .then(res => {
+      console.log('Data recieved from API:', res.data);
+      callback(null, res.data);
+    })
+    .catch(err => {
+      console.log('API', err);
+      callback(err, null);
+    });
+};
+
 module.exports = {
-  // get: {
-  //   products:
-  // }
+  get: {
+    products: (cb, id = null) => (getByEndpoint('/products', cb)),
+    reviews: (cb, id = null) => (getByEndpoint('/reviews/', cb)),
+    qa: (cb, id = null) => (getByEndpoint('/reviews'))
+
+
+  },
   getProducts: (callback) => {
     return axios.get('/products')
       .then(res => {
@@ -16,6 +33,22 @@ module.exports = {
       })
       .catch(err => {
         // console.log('API', err);
+        callback(err, null);
+      });
+  },
+  fwd: (req, res, callback) => {
+    const endpoint = req.url;
+    console.log(endpoint);
+    if (req.method === 'POST') {
+
+    }
+
+    return axios.get(req.url)
+      .then(response => {
+        callback(null, response.data);
+      })
+      .catch(err => {
+        // console.log('API', err.stack);
         callback(err, null);
       });
   }


### PR DESCRIPTION
- Created `/server/api.js` which exports `getProducts()`
- Added a route to `server.js` which runs `getProducts` on a GET request to `/products` (on localhost)
- Confirmed successful communication between our server and the API with `curl http://localhost:3000/products`