### PR TITLE
Refactors Related Products to use App cache exclusively

### DIFF
--- a/client/src/components/css/RelatedProducts.css
+++ b/client/src/components/css/RelatedProducts.css
@@ -104,6 +104,7 @@
 }
 
 .rp-card-placeholder {
+  /* border-color: #0000; */
   display: flex;
   flex-flow: column;
   justify-content: center;

--- a/client/src/components/related/Outfit.jsx
+++ b/client/src/components/related/Outfit.jsx
@@ -1,20 +1,10 @@
 import React from 'react';
 import ProductCard from './ProductCard.jsx';
-// import localStorage from '../../helpers/localStorage.js';
 import axios from 'axios';
-// import '../css/RelatedProducts.css';
-
-//
-// Try to use product ids instead of products for performance reasons
-//
 
 const Outfit = (props) => {
   const { selectedProduct, selectProduct, outfit, updateOutfit } = props;
   const { localStorage } = window;
-
-  // const update = (newOutfit) => {
-  //   props.updateOutfit(newOutfit);
-  // };
 
   const addToOutfit = () => {
     if (outfit && outfit.includes(selectedProduct)) {
@@ -41,9 +31,6 @@ const Outfit = (props) => {
     newOutfit.length ? localStorage.setItem('outfit', JSON.stringify(newOutfit.map(item => item.id))) : localStorage.removeItem('outfit');
     updateOutfit(newOutfit);
   };
-
-  // const { outfit } = this.state;
-  // console.log('Products in current outfit:', products);
 
   let key = 0;
   return selectedProduct ? (

--- a/client/src/components/related/Outfit.jsx
+++ b/client/src/components/related/Outfit.jsx
@@ -27,8 +27,7 @@ const Outfit = (props) => {
     updateOutfit(newOutfit);
   };
 
-  const removeFromOutfit = (event, product) => {
-    event.stopPropagation();
+  const removeFromOutfit = (product) => {
     const match = product.id;
     const newOutfit = [ ...outfit ];
     console.log('Remove', match);

--- a/client/src/components/related/ProductCard.jsx
+++ b/client/src/components/related/ProductCard.jsx
@@ -26,7 +26,8 @@ const ProductCard = (props) => {
   // console.log(`Rendering card for ${product.name}`);
   let trimmedTitle = `${product.name}: ${product.slogan.toLowerCase()}`;
   if (trimmedTitle.length > maxTitleTextLength) {
-    trimmedTitle = trimmedTitle.slice(0, trimmedTitle.indexOf(' ', maxTitleTextLength - 10)) + '...';
+    const endIndex = Math.min(trimmedTitle.indexOf('.'), trimmedTitle.indexOf(' ', maxTitleTextLength - 10));
+    trimmedTitle = trimmedTitle.slice(0, endIndex) + '...';
   }
 
   let key = 0;

--- a/client/src/components/related/ProductCard.jsx
+++ b/client/src/components/related/ProductCard.jsx
@@ -10,6 +10,15 @@ const ProductCard = (props) => {
   const { product, selectedProduct, selectProduct, type, action, value } = props;
   let hoverText, actionClass, actionSymbol;
 
+  const handleActionButtonClick = (event) => {
+    event.stopPropagation();
+    action(product);
+  };
+
+  const handleProductClick = () => {
+    selectProduct(product);
+  };
+
   if (type !== 'placeholder') {
     if (type === 'outfit') {
       hoverText = `Remove ${product.name} from outfit`;
@@ -34,10 +43,10 @@ const ProductCard = (props) => {
   return type === 'placeholder' ? (
     <div className='rp-card rp-card-placeholder' >{value}</div>
   ) : (
-    <div className='rp-card' title={`Select ${product.name}`} onClick={() => { selectProduct(product); }}>
+    <div className='rp-card' title={`Select ${product.name}`} onClick={ handleProductClick }>
       <div className='rp-image-backer'>
         <img src=''></img>
-        <div className={actionClass} title={hoverText} value={product.id} onClick={ (event) => { action(event, product); }}>{actionSymbol}</div>
+        <div className={actionClass} title={hoverText} value={product.id} onClick={ handleActionButtonClick } >{actionSymbol}</div>
       </div>
       <div className='rp-info'>
         <span className='rp-category'>{product.category.toUpperCase()}</span>

--- a/client/src/components/related/ProductsCarousel.jsx
+++ b/client/src/components/related/ProductsCarousel.jsx
@@ -27,7 +27,7 @@ const ProductsCarousel = (props) => {
             />;
           })
         ) : (
-          <div className='rp-card rp-card-placeholder'>Loading...</div>
+          <div className='rp-card rp-card-placeholder'>Searching...</div>
         )}
       </div>
     </div>

--- a/client/src/components/related/RelatedProducts.jsx
+++ b/client/src/components/related/RelatedProducts.jsx
@@ -32,13 +32,13 @@ class RelatedProducts extends React.Component {
     let ids = checkCache('relatedIds', id);
 
     if (ids) {
-      console.log(`${ids.length} products associated with ${product.name}:`, ids);
+      // console.log(`${ids.length} products associated with ${product.name}:`, ids);
       callback(ids);
     } else {
       axios.get(`/products/${id}/related`)
         .then(res => {
           ids = res.data;
-          console.log(`${ids.length} product ids associated with ${product.name}`, ids);
+          // console.log(`${ids.length} product ids associated with ${product.name}`, ids);
           updateCache('relatedIds', id, ids);
           callback(ids);
         })
@@ -59,7 +59,7 @@ class RelatedProducts extends React.Component {
     uniqueIds.forEach(id => {
       let product = checkCache('products', id);
       if (product) {
-        console.log(`Related product ${product.id} (${product.name}) loaded from cache`);
+        // console.log(`Related product ${product.id} (${product.name}) loaded from cache`);
         cached.push(product);
       } else {
         cached.push(id);
@@ -79,7 +79,7 @@ class RelatedProducts extends React.Component {
           .then(res => {
             const product = res.data;
             const relatedProducts = [ ...this.state.related ];
-            console.log(`Related product ${product.id} (${product.name}) retrieved from server`);
+            // console.log(`Related product ${product.id} (${product.name}) retrieved from server`);
             updateCache('products', id, product);
             this.setState({
               related: [ ...relatedProducts, product ]
@@ -121,7 +121,7 @@ class RelatedProducts extends React.Component {
 
     if (outfitData) {
       const outfit = JSON.parse(outfitData);
-      console.log('Outfit found in localStorage:', outfit);
+      // console.log('Outfit found in localStorage:', outfit);
       const { checkCache, updateCache } = this.props;
       let cached = [];
       let index = 0;
@@ -131,7 +131,7 @@ class RelatedProducts extends React.Component {
 
         if (product) {
           cached[index++] = product;
-          console.log(`Outfit product ${product.id} (${product.name}) loaded from cache`);
+          // console.log(`Outfit product ${product.id} (${product.name}) loaded from cache`);
           this.setState({ outfit: [ ...cached ] });
         } else {
           const asyncIndex = index++;
@@ -139,7 +139,7 @@ class RelatedProducts extends React.Component {
             .then(res => {
               const product = res.data;
               cached[asyncIndex] = product;
-              console.log(`Outfit product ${product.id} (${product.name}) retrived from server`);
+              // console.log(`Outfit product ${product.id} (${product.name}) retrived from server`);
               this.setState({ outfit: [ ...cached ] });
               updateCache('products', product.id, product);
             })
@@ -152,25 +152,8 @@ class RelatedProducts extends React.Component {
   }
 
   updateOutfit(newOutfit) {
-    // console.log('Related products updating outfit:', newOutfit);
     this.setState({ outfit: newOutfit });
   }
-
-  // mapAllProductsById() {
-  //   return axios.get('/products?count=1000000')
-  //     .then(res => {
-  //       const { products: map } = this.store;
-  //       const allProducts = res.data;
-  //       for (let i = 0, end = allProducts.length; i < end; i++) {
-  //         const product = allProducts[i];
-  //         map.set(product.id, product);
-  //       }
-  //       this.products = allProducts;
-  //     })
-  //     .catch(err => {
-  //       console.log(err.stack);
-  //     });
-  // }
 
   selectProduct(product) {
     this.props.selectProduct(product);
@@ -192,23 +175,25 @@ class RelatedProducts extends React.Component {
 
   render() {
     const { related, outfit } = this.state;
-    const { selectedProduct, selectProduct } = this.props;
+    const { selectedProduct, selectProduct, checkCache, updateCache } = this.props;
 
     return (
       <div id='RelatedProdcuts'>
         <ProductsCarousel
-          // key={ selectedProduct }
           products={ related }
           selectedProduct={ selectedProduct }
           selectProduct={ this.selectProduct }
+          checkCache={ checkCache }
+          updateCache={ updateCache }
         />
         <Outfit
           outfit={ outfit }
           updateOutfit={ this.updateOutfit }
           selectedProduct={ selectedProduct }
           selectProduct={ this.selectProduct }
+          checkCache={ checkCache }
+          updateCache={ updateCache }
         />
-        {/* <RelatedProductsOutfit /> */}
       </div>
     );
   }

--- a/client/src/components/related/RelatedProducts.jsx
+++ b/client/src/components/related/RelatedProducts.jsx
@@ -12,13 +12,13 @@ class RelatedProducts extends React.Component {
     this.selectProduct = this.selectProduct.bind(this);
     this.updateOutfit = this.updateOutfit.bind(this);
 
-    this.productList = this.props.products;
-    this.toLoad = [];
+    // this.productList = this.props.products;
+    // this.toLoad = [];
 
-    this.store = {
-      products: new Map(),
-      related: new Map()
-    };
+    // this.cache = {
+    //   products: new Map(),
+    //   related: new Map()
+    // };
 
 
     this.state = {
@@ -38,8 +38,10 @@ class RelatedProducts extends React.Component {
 
   fetchRelatedIds(product, callback = () => {}) {
     const id = product.id;
-    const { related } = this.store;
-    let ids = related.get(product.id);
+    // const { related } = this.cache;
+    const { checkCache, updateCache } = this.props;
+    // let ids = related.get(product.id);
+    let ids = checkCache('relatedIds', id);
 
     if (ids) {
       console.log(`${ids.length} products associated with ${product.name}:`, ids);
@@ -49,7 +51,7 @@ class RelatedProducts extends React.Component {
         .then(res => {
           ids = res.data;
           console.log(`${ids.length} product ids associated with ${product.name}`, ids);
-          related.set(id, ids);
+          updateCache('relatedIds', id, ids);
           callback(ids);
           // this.setState({ related: res.data });
         })
@@ -61,14 +63,16 @@ class RelatedProducts extends React.Component {
 
   collectProductsById(ids) {
     // Choose between cached data or API call on a per-product basis
-    const { products } = this.store;
+    // const { products } = this.cache;
+    const { checkCache, updateCache } = this.props;
     const uniqueIds = Array.from(new Set(ids));
 
     let cached = [];
     let toLoad = [];
 
     uniqueIds.forEach(id => {
-      let product = products.get(id);
+      // let product = products.get(id);
+      let product = checkCache('products', id);
       if (product) {
         console.log(`Related product ${product.id} (${product.name}) loaded from cache`);
         cached.push(product);
@@ -91,8 +95,9 @@ class RelatedProducts extends React.Component {
             const product = res.data;
             const relatedProducts = [ ...this.state.related ];
             console.log(`Related product ${product.id} (${product.name}) retrieved from server`);
-            this.productList.push(product);
-            products.set(id, product);
+            // this.productList.push(product);
+            // products.set(id, product);
+            updateCache('products', id, product);
             this.setState({
               related: [ ...relatedProducts, product ]
             });
@@ -134,12 +139,14 @@ class RelatedProducts extends React.Component {
     if (outfitData) {
       const outfit = JSON.parse(outfitData);
       console.log('Outfit found in localStorage:', outfit);
-      const { products } = this.store;
+      // const { products } = this.cache;
+      const { checkCache, updateCache } = this.props;
       let cached = [];
       let index = 0;
 
       outfit.forEach(id => {
-        let product = products.get(id);
+        // let product = products.get(id);
+        let product = checkCache('products', id);
 
         if (product) {
           cached[index++] = product;
@@ -153,7 +160,8 @@ class RelatedProducts extends React.Component {
               cached[asyncIndex] = product;
               console.log(`Outfit product ${product.id} (${product.name}) retrived from server`);
               this.setState({ outfit: [ ...cached ] });
-              products.set(product.id, product);
+              // products.set(product.id, product);
+              updateCache('products', product.id, product);
             })
             .catch(err => {
               console.log('Loading outfit:', err.stack);
@@ -185,8 +193,8 @@ class RelatedProducts extends React.Component {
   // }
 
   selectProduct(product) {
-    const { updateProductData, selectProduct } = this.props;
-    updateProductData(this.productList, this.store.products);
+    const { selectProduct } = this.props;
+    // updateProductData(this.productList, this.cache.products);
     // this.collectRelatedProducts(product);
     this.props.selectProduct(product);
     this.setState({ ready: false });

--- a/client/src/components/related/RelatedProducts.jsx
+++ b/client/src/components/related/RelatedProducts.jsx
@@ -12,15 +12,6 @@ class RelatedProducts extends React.Component {
     this.selectProduct = this.selectProduct.bind(this);
     this.updateOutfit = this.updateOutfit.bind(this);
 
-    // this.productList = this.props.products;
-    // this.toLoad = [];
-
-    // this.cache = {
-    //   products: new Map(),
-    //   related: new Map()
-    // };
-
-
     this.state = {
       selected: this.props.selectedProduct.id,
       related: [],
@@ -30,7 +21,6 @@ class RelatedProducts extends React.Component {
   }
 
   collectRelatedProducts(product) {
-    // console.log('reset related products');
     this.fetchRelatedIds(product, (ids) => {
       this.collectProductsById(ids);
     });
@@ -38,9 +28,7 @@ class RelatedProducts extends React.Component {
 
   fetchRelatedIds(product, callback = () => {}) {
     const id = product.id;
-    // const { related } = this.cache;
     const { checkCache, updateCache } = this.props;
-    // let ids = related.get(product.id);
     let ids = checkCache('relatedIds', id);
 
     if (ids) {
@@ -53,7 +41,6 @@ class RelatedProducts extends React.Component {
           console.log(`${ids.length} product ids associated with ${product.name}`, ids);
           updateCache('relatedIds', id, ids);
           callback(ids);
-          // this.setState({ related: res.data });
         })
         .catch(err => {
           console.log(err.stack);
@@ -63,7 +50,6 @@ class RelatedProducts extends React.Component {
 
   collectProductsById(ids) {
     // Choose between cached data or API call on a per-product basis
-    // const { products } = this.cache;
     const { checkCache, updateCache } = this.props;
     const uniqueIds = Array.from(new Set(ids));
 
@@ -71,7 +57,6 @@ class RelatedProducts extends React.Component {
     let toLoad = [];
 
     uniqueIds.forEach(id => {
-      // let product = products.get(id);
       let product = checkCache('products', id);
       if (product) {
         console.log(`Related product ${product.id} (${product.name}) loaded from cache`);
@@ -95,8 +80,6 @@ class RelatedProducts extends React.Component {
             const product = res.data;
             const relatedProducts = [ ...this.state.related ];
             console.log(`Related product ${product.id} (${product.name}) retrieved from server`);
-            // this.productList.push(product);
-            // products.set(id, product);
             updateCache('products', id, product);
             this.setState({
               related: [ ...relatedProducts, product ]
@@ -139,13 +122,11 @@ class RelatedProducts extends React.Component {
     if (outfitData) {
       const outfit = JSON.parse(outfitData);
       console.log('Outfit found in localStorage:', outfit);
-      // const { products } = this.cache;
       const { checkCache, updateCache } = this.props;
       let cached = [];
       let index = 0;
 
       outfit.forEach(id => {
-        // let product = products.get(id);
         let product = checkCache('products', id);
 
         if (product) {
@@ -160,7 +141,6 @@ class RelatedProducts extends React.Component {
               cached[asyncIndex] = product;
               console.log(`Outfit product ${product.id} (${product.name}) retrived from server`);
               this.setState({ outfit: [ ...cached ] });
-              // products.set(product.id, product);
               updateCache('products', product.id, product);
             })
             .catch(err => {
@@ -193,23 +173,11 @@ class RelatedProducts extends React.Component {
   // }
 
   selectProduct(product) {
-    const { selectProduct } = this.props;
-    // updateProductData(this.productList, this.cache.products);
-    // this.collectRelatedProducts(product);
     this.props.selectProduct(product);
     this.setState({ ready: false });
   }
 
   componentDidMount() {
-    // In the future this will also need to identify the user and bring up their selected outfit from their past session
-    // this.mapAllProductsById()
-    //   .then(() => {
-    //     this.props.updateProductData(this.products, this.store.products);
-    //     this.collectRelatedProducts(this.props.selectedProduct);
-    //   })
-    //   .catch(err => {
-    //     console.log(err.stack);
-    //   });
     this.loadOutfit();
     this.collectRelatedProducts(this.props.selectedProduct);
   }
@@ -226,9 +194,6 @@ class RelatedProducts extends React.Component {
     const { related, outfit } = this.state;
     const { selectedProduct, selectProduct } = this.props;
 
-    // console.log('Related products:', related);
-
-    // console.log('RelatedProducts re-render');
     return (
       <div id='RelatedProdcuts'>
         <ProductsCarousel

--- a/client/src/helpers/localStorage.js
+++ b/client/src/helpers/localStorage.js
@@ -1,8 +1,0 @@
-const array = (key) => {
-  const storage = window.localStorage;
-  const value = storage.getItem(key);
-
-  return value ? JSON.parse(value) : undefined;
-};
-
-export default array;

--- a/client/src/index.jsx
+++ b/client/src/index.jsx
@@ -28,6 +28,7 @@ class App extends React.Component {
       questions: new Map(),
       ratings: new Map(),
       relatedIds: new Map(),
+      styles: new Map(),
     };
 
     this.state = {

--- a/client/src/index.jsx
+++ b/client/src/index.jsx
@@ -14,10 +14,7 @@ class App extends React.Component {
   constructor(props) {
     super(props);
 
-    this.handleUpdate = this.handleUpdate.bind(this);
     this.selectProduct = this.selectProduct.bind(this);
-    this.handleSelectChange = this.handleSelectChange.bind(this);
-    // this.updateProductData = this.updateProductData.bind(this);
     this.checkCache = this.checkCache.bind(this);
     this.updateCache = this.updateCache.bind(this);
 
@@ -34,30 +31,10 @@ class App extends React.Component {
     this.state = {
       ready: false,
       selectedProduct: null,
-      // products: [],
       selectedProductRating: { ratingsCount: undefined, avgRating: undefined, ratings: [] },
       selectedProductImageURLs: [],
       selectedProductThumbnailURLs: []
     };
-  }
-
-  handleUpdate(urlToReload, stateKeyToUpdate) {
-    if (this.props.isTesting) {
-      return new Promise((resolve, reject) => {
-        resolve();
-        reject();
-      });
-    }
-
-    return axios.get(urlToReload)
-      .then(res => {
-        this.setState({
-          [stateKeyToUpdate]: res.data
-        });
-      })
-      .catch(err => {
-        console.log(err.stack);
-      });
   }
 
   selectProduct(product) {
@@ -75,52 +52,15 @@ class App extends React.Component {
     this.cache[cacheName].set(productId, data);
   }
 
-  // updateImageURLs(imageURLs, thumbnailURLs) {
-  //   const { id } = this.state.selectedProduct;
-  //   this.cache.imageURLs.set(id, { imageURLs, thumbnailURLs });
-  //   this.setState({
-  //     selectedProductImageURLs: imageURLs,
-  //     selectedProductThumbnailURLs: thumbnailURLs
-  //   });
-  // }
-
-  // updateProductCache(productList, productMap) {
-  //   this.cache.products = productMap;
-  //   this.setState({
-  //     products: productList
-  //   });
-  // }
-
-  // this.props.updateRatings(ratings.length, ratings.reduce((total, rating) => (total + rating)) / ratings.length);
-
-  // updateSelectedProductRatings(ratings) {
-  //   const { id } = this.state.selectedProduct;
-  //   this.cache.ratings.set(id, {
-  //     ratingsCount: ratings.length,
-  //     avgRating: ratings.reduce((total, rating) => (total + rating)) / ratings.length
-  //   });
-  //   this.setState({
-  //     rating:
-  //   })
-  // }
-
-  handleSelectChange(e) {
-    const { products } = this.cache;
-    const productId = parseInt(e.currentTarget.value);
-    const selectedProduct = products.get(productId);
-    this.selectProduct(selectedProduct);
-  }
-
   componentDidMount() {
-    axios.get('/products')
+    const randomInitialId = 28212 + Math.round(Math.random() * 10);
+    axios.get(`/products/${randomInitialId}`)
       .then(res => {
-        const products = res.data;
-        products.forEach(product => {
-          this.cache.products.set(product.id, product);
-        });
+        const product = res.data;
+        this.cache.products.set(product.id, product);
         this.setState({
-          products: products,
-          selectedProduct: products[Math.floor(Math.random() * products.length)],
+          products: [product],
+          selectedProduct: product,
           ready: true
         });
       });
@@ -132,17 +72,11 @@ class App extends React.Component {
       console.log('select product', selectedProduct.id);
 
     }
-    //console.log('App re-render');
     let key = 0;
     return ready ? (
       <div id='app'>
-        <h3>{`${selectedProduct.name} selected`}</h3>
-        <select name='productSelector' value={selectedProduct.id} onChange={this.handleSelectChange}>
-          {products.map(product => (<option key={`product${key++}`} value={product.id}>{product.name}</option>))}
-        </select>
         <ProductOverview
           selectedProduct={selectedProduct}
-          // ratings={this.store.ratings}
           isTesting={this.props.isTesting}
         />
         <RelatedProducts
@@ -150,8 +84,7 @@ class App extends React.Component {
           selectProduct={this.selectProduct}
           checkCache={ this.checkCache }
           updateCache={ this.updateCache }
-          // products={products}
-          // updateProductData={this.updateProductData}
+
         />
         <QA productId={selectedProduct.id} />
         <br></br>

--- a/client/src/index.jsx
+++ b/client/src/index.jsx
@@ -17,19 +17,26 @@ class App extends React.Component {
     this.handleUpdate = this.handleUpdate.bind(this);
     this.selectProduct = this.selectProduct.bind(this);
     this.handleSelectChange = this.handleSelectChange.bind(this);
-    this.updateProductData = this.updateProductData.bind(this);
+    // this.updateProductData = this.updateProductData.bind(this);
+    this.checkCache = this.checkCache.bind(this);
+    this.updateCache = this.updateCache.bind(this);
 
 
     this.cache = {
+      imageURLs: new Map(),
       products: new Map(),
       questions: new Map(),
       ratings: new Map(),
+      relatedIds: new Map(),
     };
 
     this.state = {
       ready: false,
-      products: [],
-      selectedProduct: null
+      selectedProduct: null,
+      // products: [],
+      selectedProductRating: { ratingsCount: undefined, avgRating: undefined, ratings: [] },
+      selectedProductImageURLs: [],
+      selectedProductThumbnailURLs: []
     };
   }
 
@@ -59,12 +66,42 @@ class App extends React.Component {
     });
   }
 
-  updateProductData(productList, productMap) {
-    this.cache.products = productMap;
-    this.setState({
-      products: productList
-    });
+  checkCache(cacheName, productId) {
+    return this.cache[cacheName].get(productId);
   }
+
+  updateCache(cacheName, productId, data) {
+    this.cache[cacheName].set(productId, data);
+  }
+
+  // updateImageURLs(imageURLs, thumbnailURLs) {
+  //   const { id } = this.state.selectedProduct;
+  //   this.cache.imageURLs.set(id, { imageURLs, thumbnailURLs });
+  //   this.setState({
+  //     selectedProductImageURLs: imageURLs,
+  //     selectedProductThumbnailURLs: thumbnailURLs
+  //   });
+  // }
+
+  // updateProductCache(productList, productMap) {
+  //   this.cache.products = productMap;
+  //   this.setState({
+  //     products: productList
+  //   });
+  // }
+
+  // this.props.updateRatings(ratings.length, ratings.reduce((total, rating) => (total + rating)) / ratings.length);
+
+  // updateSelectedProductRatings(ratings) {
+  //   const { id } = this.state.selectedProduct;
+  //   this.cache.ratings.set(id, {
+  //     ratingsCount: ratings.length,
+  //     avgRating: ratings.reduce((total, rating) => (total + rating)) / ratings.length
+  //   });
+  //   this.setState({
+  //     rating:
+  //   })
+  // }
 
   handleSelectChange(e) {
     const { products } = this.cache;
@@ -108,10 +145,12 @@ class App extends React.Component {
           isTesting={this.props.isTesting}
         />
         <RelatedProducts
-          products={products}
           selectedProduct={selectedProduct}
-          updateProductData={this.updateProductData}
           selectProduct={this.selectProduct}
+          checkCache={ this.checkCache }
+          updateCache={ this.updateCache }
+          // products={products}
+          // updateProductData={this.updateProductData}
         />
         <QA productId={selectedProduct.id} />
         <br></br>

--- a/tests/client/src/components/related/relatedProducts.test.js
+++ b/tests/client/src/components/related/relatedProducts.test.js
@@ -18,7 +18,7 @@ const selectedProduct = {
 // const selectedProduct = product;
 
 describe('<RelatedProducts />', () => {
-  const component = mount(<RelatedProducts products={products} selectedProduct={selectedProduct} />);
+  const component = mount(<RelatedProducts products={products} selectedProduct={selectedProduct} checkCache={() => {}} updateCache={() => {}} />);
 
   it('renders', () => {
     expect(component.find('div.rp-card')).toBeTruthy();


### PR DESCRIPTION
Just some scaffolding to facilitate more/easier sharing of data between components.

Passing `checkCache` and `updateCache` and using them to supply props to your subcomponents will allow everyone to share data at the main app level without the unavoidable re-rendering that would come along with state/props updates.

Example usage:
`this.props.checkCache('products', productId);`
(Returns product data, if present, or `undefined`)
`this.props.updateCache('imageURLs', productId, { fullSizeURLs: arrayOfURLs, thumbnailURLs: arrayOfURLs });`
(Caches lists of image URLs associated with a given product id)
`this.props.updateCache('ratings', productId, { ratingsCount: ratings.length, avgRating: ratings.reduce((total, rating) => (total + rating)) / ratings.length });`
(Caches number of ratings and average rating associated with a given product id)